### PR TITLE
Base menu visibility off of target URL (rather than current page)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ It also ensures that the CreatorID is correctly added to the URL, so you don't h
 
 ## Options
 
-After you have installed the extension, please specify your CreateorIDs within the extension options:
+After you have installed the extension, please specify your CreatorIDs within the extension options:
 
 ![Extension Options](./assets/screenshot_options.png)

--- a/src/options.js
+++ b/src/options.js
@@ -48,8 +48,8 @@ function createContextMenues(creatorIds) {
     chrome.contextMenus.create({
         title: 'Copy link address with CreatorID',
         id: parentId,
-        documentUrlPatterns: [
-            "http://social.technet.microsoft.com/*",
+        targetUrlPatterns: [
+            "https://social.technet.microsoft.com/*",
             "https://docs.microsoft.com/*",
             "https://azure.microsoft.com/*",
             "https://techcommunity.microsoft.com/*",


### PR DESCRIPTION
Change menu visibility so it is determined by the matching of the target link, instead of the current page.

Fixes #5 