### PR TITLE
Add Cloud Skills Challenge URL

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -65,7 +65,8 @@ function createContextMenues(creatorIds) {
             "https://msdn.microsoft.com/*",
             "https://blogs.msdn.microsoft.com/*",
             "https://blogs.technet.microsoft.com/*",
-            "https://microsoft.com/handsonlabs/*"
+            "https://microsoft.com/handsonlabs/*",
+            "https://csc.docs.microsoft.com/*"
         ],
         contexts: ['link']
     });


### PR DESCRIPTION
This URL is being used for the Cloud Skills Challenge.

eg. https://csc.docs.microsoft.com/build/registration/2021/?WT.mc_id=DOP-MVP-5001655